### PR TITLE
Fix razor configuration task in eFa-Commit

### DIFF
--- a/rpmbuild/SOURCES/eFa-base-4.0.0/eFa/eFa-Commit
+++ b/rpmbuild/SOURCES/eFa-base-4.0.0/eFa/eFa-Commit
@@ -749,7 +749,7 @@ if [[ $configrazor -eq 1 ]]; then
   else
     samplepath='spamassassin'
   fi
-  su -c "/bin/cat /usr/share/doc/$samplepath/sample-spam.txt | razor-report -d --verbose" -s /bin/bash postfix
+  su -l -c "/bin/cat /usr/share/doc/$samplepath/sample-spam.txt | razor-report -d --verbose" -s /bin/bash postfix
   touch /var/spool/postfix/.razor/razor-agent.log
   [ $? -ne 0 ] && exit 1
   chown -R postfix:mtagroup /var/spool/postfix/.razor


### PR DESCRIPTION
This _should_ fix the problem running the razor configuration task:

Without fix:
```
Can't locate Razor2/Client/Agent.pm:   lib/Razor2/Client/Agent.pm: Permission denied at /usr/bin/razor-report line 15.
BEGIN failed--compilation aborted at /usr/bin/razor-report line 15.
```

With fix:
```
[eFa] - Configuring razor
Register successful.  Identity stored in /var/spool/postfix/.razor/identity-ruAUBpc-ZR
 Razor-Log: Computed razorhome from env: /var/spool/postfix/.razor
 Razor-Log: Found razorhome: /var/spool/postfix/.razor
 Razor-Log: read_file: 16 items read from /var/spool/postfix/.razor/razor-agent.conf
Oct 27 23:01:00.201874 report[2131]: [ 2] [bootup] Logging initiated LogDebugLevel=9 to stdout
Oct 27 23:01:00.201972 report[2131]: [ 5] computed razorhome=/var/spool/postfix/.razor, conf=/var/spool/postfix/.razor/raz         or-agent.conf, ident=/var/spool/postfix/.razor/identity-ruAUBpc-ZR
Oct 27 23:01:00.201994 report[2131]: [ 2]  Razor-Agents v2.84 starting razor-report -d --verbose
Oct 27 23:01:00.202058 report[2131]: [ 5] read_file: 2 items read from /var/spool/postfix/.razor/identity-ruAUBpc-ZR
Oct 27 23:01:00.202373 report[2131]: [ 8] razor-report finished successfully.
Oct 27 23:01:00.208268 report[2132]: [ 8] reading straight RFC822 mail from <stdin>
Oct 27 23:01:00.208370 report[2132]: [ 6] read 1 mail
Oct 27 23:01:00.208468 report[2132]: [ 8] Client supported_engines: 4 8
...
```