### PR TITLE
updates mailwatch to 1.2.17 and enables fail2ban to block failed mailwatch logins

### DIFF
--- a/rpmbuild/SOURCES/eFa-4.0.4/eFa/lib-eFa-Configure/func_fail2ban
+++ b/rpmbuild/SOURCES/eFa-4.0.4/eFa/lib-eFa-Configure/func_fail2ban
@@ -29,6 +29,7 @@ enabled = true
 
 [postfix-sasl]
 enabled = true
+filter = postfix[mode=auth]
 
 [mailwatch]
 enabled = true

--- a/rpmbuild/SOURCES/eFa-4.0.4/eFa/lib-eFa-Configure/func_fail2ban
+++ b/rpmbuild/SOURCES/eFa-4.0.4/eFa/lib-eFa-Configure/func_fail2ban
@@ -18,12 +18,12 @@ function func_fail2ban() {
         if [[ $ASK =~ ^[yY]$ || -z $ASK ]]; then
             flag=1
 
-            if [[ -f /etc/fail2ban/jail.d/jail.local.old ]]; then
-                if [[ ! -f /etc/fail2ban/jail.d/jail.local ]]; then
-                    mv /etc/fail2ban/jail.d/jail.local.old /etc/fail2ban/jail.d/jail.local
+            if [[ -f /etc/fail2ban/jail.d/efa.local.disabled ]]; then
+                if [[ ! -f /etc/fail2ban/jail.d/efa.local ]]; then
+                    mv /etc/fail2ban/jail.d/efa.local.disabled /etc/fail2ban/jail.d/efa.local
                 fi
             else
-                cat > /etc/fail2ban/jail.d/jail.local << 'EOF'
+                cat > /etc/fail2ban/jail.d/efa.local << 'EOF'
 [sshd]
 enabled = true
 
@@ -54,7 +54,7 @@ EOF
             pause
         elif [[ $ASK =~ ^[nN]$ ]]; then
             flag=1
-            mv /etc/fail2ban/jail.d/jail.local /etc/fail2ban/jail.d/jail.local.old
+            mv /etc/fail2ban/jail.d/efa.local /etc/fail2ban/jail.d/efa.local.disabled
             systemctl disable fail2ban
             systemctl stop fail2ban
 

--- a/rpmbuild/SOURCES/eFa-4.0.4/eFa/lib-eFa-Configure/func_fail2ban
+++ b/rpmbuild/SOURCES/eFa-4.0.4/eFa/lib-eFa-Configure/func_fail2ban
@@ -29,7 +29,21 @@ enabled = true
 
 [postfix-sasl]
 enabled = true
+
+[mailwatch]
+enabled = true
+port    = http,https
+logpath = /var/log/php-fpm/www-error.log
 EOF
+
+                cat > /etc/fail2ban/filter.d/mailwatch.conf << 'EOF'
+[Definition]
+
+failregex = ^\[.*?\] MailWatch failed login attempt from\: \[<HOST>\] for User: .*?$
+
+ignoreregex =
+EOF
+
             fi
 
             systemctl enable fail2ban

--- a/rpmbuild/SPECS/MailWatch.spec
+++ b/rpmbuild/SPECS/MailWatch.spec
@@ -26,7 +26,7 @@
 #-----------------------------------------------------------------------------#
 Summary:       MailWatch Web Front-End for MailScanner
 Name:          MailWatch
-Version:       1.2.16
+Version:       1.2.17
 Epoch:         1
 Release:       1.eFa%{?dist}
 License:       GNU GPL v2
@@ -310,6 +310,9 @@ chgrp apache %{_localstatedir}/www/html/mailscanner/temp
 %{_localstatedir}/www/html/mailscanner/viewpart.php
 
 %changelog
+* Tue Jan 05 2021 Tobias Perschon <tobias@perschon.at> - 1.2.17-1
+- Update to v1.2.17
+
 * Tue Jan 05 2021 Shawn Iverson <shawniverson@efa-project.org> - 1.2.16-1
 - Update to v1.2.16
 

--- a/rpmbuild/SPECS/eFa4.spec
+++ b/rpmbuild/SPECS/eFa4.spec
@@ -195,7 +195,7 @@ Requires:  perl-libnet >= 3.11-1
     # perl-libnet                                # eFa     # Spamassassin
 Requires:  perl-Encoding-FixLatin >= 1.04-1
     # perl-Encoding-FixLatin                     # eFa     # MailWatch
-Requires:  MailWatch >= 1:1.2.16-1
+Requires:  MailWatch >= 1:1.2.17-1
     # MailWatch                                  # eFa     # MailWatch Frontend
 Requires:  dcc >= 2.3.167-1
     # dcc                                        # eFa     # Spamassassin, MailScanner


### PR DESCRIPTION
With mailwatch 1.2.17 failed login attempts are logged to the php error log. 
I added a new filter to the fail2ban setup that catches the failed logins and blocks them.

we would need to add this to some kind of update script as well, so existing installs with enabled fail2ban get the jail and config as well.

But I would also propose to not touch the jail.local but instead add a file efa.local to /etc/fail2ban/jail.d/ and add everything there - would also make updating in the future easier... Would you agree? if so then I will push the necessary changes...

cheers,
Tobias