### PR TITLE
eFa-Backup.cron: Permanently disabling backups

### DIFF
--- a/rpmbuild/SOURCES/eFa-4.0.4/eFa/eFa-Backup.cron
+++ b/rpmbuild/SOURCES/eFa-4.0.4/eFa/eFa-Backup.cron
@@ -18,6 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # +--------------------------------------------------------------------+
+
+# Exit if backup disabled
+[[ -f /etc/eFa/eFa-Backup.disabled ]] && exit 0
+
 [[ -f /var/log/eFa/eFa-Backup.log ]] || touch /var/log/eFa/eFa-Backup.log
 /usr/sbin/eFa-Backup-cron -backup >> /var/log/eFa/eFa-Backup.log 2>&1
 /usr/sbin/eFa-Backup-cron -purge >> /var/log/eFa/eFa-Backup.log 2>&1


### PR DESCRIPTION
Allow system admin to disable backups by touching file /etc/eFa/eFa-Backup.disabled

This is really useful when running eFa in a VM that is being already being backed up at storage level and need no additional resources intensive local backup.